### PR TITLE
monkey patch to fix bold in xlsx files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ docopt==0.6.2
 xypath==1.1.0
 xlutils==2.0.0
 pyhamcrest==1.9.0
+openpyxl==3.0.5


### PR DESCRIPTION
`is_bold` and `is_not_bold` don't work with xslx files, it's because messytables used the xlrd library to get excel properties and it cant read them from xslx (just xls).

this is just a monkey patch to pick up that particular property via openpyexcel to overrite the getter and get us back to working.

not pretty but it works and the pretty solution is a significant rewrite of the underpinnings of the core stack (which we probably should do, but probably not now).