### PR TITLE
fix bugs in typing and bi-section recursion logic

### DIFF
--- a/databaker/jupybakeutils.py
+++ b/databaker/jupybakeutils.py
@@ -102,7 +102,12 @@ class HDim:
             assert isinstance(val, str), "Override from obs should go directly to a string-value"
             return None, val
             
-        return self.celllookup(ob)  # note - returns two values
+        # handle types before returning
+        cell, cell_value = self.celllookup(ob)
+        if cell is None:
+            return None, cell_value
+        else:
+            return cell, svalue(cell) if isinstance(cell.value, datetime.datetime) else str(cell_value)
         
     def AddCellValueOverride(self, overridecell, overridevalue):
         "Override the value of a header cell (and insert it if not present in the bag)" 

--- a/databaker/lookupengines/closest.py
+++ b/databaker/lookupengines/closest.py
@@ -47,7 +47,7 @@ class ClosestEngine(object):
         self.cellvalueoverride = cellvalueoverride if cellvalueoverride is not None else {}
 
         assert len(cell_bag) > 0, f'Aborting. The dimension {self.label} is defined as CLOSEST ' \
-                    + '{DIRECTION_DICT[self.direction]} but an empty selection of cells has been ' \
+                    + f'{DIRECTION_DICT[self.direction]} but an empty selection of cells has been ' \
                     + 'passed in as the first argument.'
 
         # the break-point is the start/end of a range. Effectively the index of the cell

--- a/databaker/lookupengines/closest.py
+++ b/databaker/lookupengines/closest.py
@@ -50,6 +50,10 @@ class ClosestEngine(object):
         self.label = label
         self.cellvalueoverride = cellvalueoverride if cellvalueoverride is not None else {}
 
+        assert len(cell_bag) > 0, f'Aborting. The dimension {self.label} is defined as CLOSEST ' \
+                    + '{DIRECTION_DICT[self.direction]} but an empty selection of cells has been ' \
+                    + 'passed in as the first argument.'
+
         # the break-point is the start/end of a range. Effectively the index of the cell
         # along the relevant axis.
         break_points = {}

--- a/databaker/lookupengines/closest.py
+++ b/databaker/lookupengines/closest.py
@@ -1,8 +1,4 @@
-import pprint as pp
-import json
-
 from databaker.constants import ABOVE, BELOW, LEFT, RIGHT, DIRECTION_DICT
-
 
 class BoundaryError(Exception):
     """ Raised when attempting to lookup outside the bounds of where a lookup can exist"""

--- a/databaker/lookupengines/directly.py
+++ b/databaker/lookupengines/directly.py
@@ -1,6 +1,3 @@
-import json
-import pprint as pp
-
 from databaker.constants import ABOVE, BELOW, LEFT, RIGHT, DIRECTION_DICT
 
 class DirectLookupException(Exception):

--- a/databaker/lookupengines/directly.py
+++ b/databaker/lookupengines/directly.py
@@ -43,6 +43,10 @@ class DirectlyEngine(object):
 
         self.tiered_dict = {}
 
+        assert len(cell_bag) > 0, f'Aborting. The dimension {self.label} is defined as DIRECTLY ' \
+                    + '{DIRECTION_DICT[self.direction]} but an empty selection of cells has been ' \
+                    + 'passed in as the first argument.'
+
         for cell in cell_bag:
 
             ## reset dictionary to starting point

--- a/databaker/lookupengines/directly.py
+++ b/databaker/lookupengines/directly.py
@@ -41,7 +41,7 @@ class DirectlyEngine(object):
         self.tiered_dict = {}
 
         assert len(cell_bag) > 0, f'Aborting. The dimension {self.label} is defined as DIRECTLY ' \
-                    + '{DIRECTION_DICT[self.direction]} but an empty selection of cells has been ' \
+                    + f'{DIRECTION_DICT[self.direction]} but an empty selection of cells has been ' \
                     + 'passed in as the first argument.'
 
         for cell in cell_bag:

--- a/features/exceptions.feature
+++ b/features/exceptions.feature
@@ -34,3 +34,27 @@ Scenario: A CLOSEST lookup where there are no dimension cells in the stated dire
         """
         Lookup for cell "<D6 1.0>" is impossible. No selected values for dimension "Month" exist in the ABOVE direction from this cell
         """
+
+Scenario: Create a CLOSEST lookup with an empty bag of cells
+    Given we load an xls file named "bakingtestdataset.xls"
+    And select the sheet "Sheet1"
+    And we define cell selections as
+        | key             | value                                              |
+        | observations    | tab.excel_ref("D6:D26")                            |
+        | month           | tab.excel_ref("D1").is_not_blank().is_blank()      |
+    Then the dimension 'HDim(month, "Month", CLOSEST, ABOVE)' will fail with the exception
+        """
+        Aborting. The dimension Month is defined as CLOSEST ABOVE but an empty selection of cells has been passed in as the first argument.
+        """
+
+Scenario: Create a DIRECTLY lookup with an empty bag of cells
+    Given we load an xls file named "bakingtestdataset.xls"
+    And select the sheet "Sheet1"
+    And we define cell selections as
+        | key             | value                                             |
+        | observations    | tab.excel_ref("D6:D7")                            | 
+        | county          | tab.excel_ref("J6").is_not_blank().is_blank()     |
+    Then the dimension 'HDim(county, "County", DIRECTLY, RIGHT)' will fail with the exception
+        """
+        Aborting. The dimension County is defined as DIRECTLY RIGHT but an empty selection of cells has been passed in as the first argument.
+        """

--- a/features/exceptions.feature
+++ b/features/exceptions.feature
@@ -58,3 +58,15 @@ Scenario: Create a DIRECTLY lookup with an empty bag of cells
         """
         Aborting. The dimension County is defined as DIRECTLY RIGHT but an empty selection of cells has been passed in as the first argument.
         """
+
+Scenario: Create a CLOSEST lookup with two equally close cells
+    Given we load an xls file named "bakingtestdataset.xls"
+    And select the sheet "Sheet1"
+    And we define cell selections as
+        | key             | value                                 |
+        | random          | tab.excel_ref("A1").expand(RIGHT)     | 
+        | observations    | tab.excel_ref("J6").is_not_blank()    |
+    Then the dimension 'HDim(random, "Random Selection", CLOSEST, ABOVE)' will fail with the exception
+        """
+        Aborting. You have defined two or more equally valid CLOSEST ABOVE relationships. Trying to add 0:{<B1 ''>} but we already have: {"0": "{<A1 'Test Title'>}"}
+        """

--- a/features/steps/load_xls.py
+++ b/features/steps/load_xls.py
@@ -205,6 +205,24 @@ def step_impl(context, dimension_label, expected_value):
         assert cell is None, f'A constant lookup should be returning type:None for the cell looked up, not {type(cell)}'
         assert cell_value == expected_value, f'Expecting {expected_value}, got {cell_value}'
 
+
+@then(u'the dimension \'{dim_constructor}\' will fail with the exception')
+def step_impl(context, dim_constructor):
+
+    if "HDimConst" in dim_constructor:
+        raise NotImplementedError(u'The step is not currently designed to accomodate a HDimConst dimension')
+
+    dc_tokens = dim_constructor.split(",")
+    dc0 = dc_tokens[0]
+    dc0 = dc0.split("(")[0]+f'(context.selections[\'{dc0.split("(")[1]}\'],'
+    ds = dc0 + ",".join(dc_tokens[1:])
+
+    try:
+        dimension = eval(ds)
+    except Exception as dim_err:
+        assert str(dim_err) == context.text, f'Expecting: \n"{context.text}\'\nGot:\n{str(dim_err)}'
+
+
 @then('the unique contents of the "{column_name}" column should be equal to')
 def step_impl(context, column_name):
     assert column_name in context.df.columns.values, 'No column named "{column_name}" present in dataframe'


### PR DESCRIPTION
fixes for issues that bubbled up during rolled back refactored databaker deployment.

issues:
1.) During the refactor we lost type casting the returned cell values to strings. Fixed in `jupybakeutils.py`.

2.) The bi section search in the CLOSEST engine wasn't correctly disregarding the unwanted half on each new iteration, it was leading to some scenarios of the choice "bouncing" between two equally incorrect choices until the recursion depth limit was hit. Added tracking for the modified "ceiling" and floor" so we never return to a discarded range. In `closest.py`.

Also adding bdd scenarios to cover the above plus a assertions/checks to cover existing quirks that we're getting confused with deployment related changes.